### PR TITLE
Update performance printouts for modular benchmarking

### DIFF
--- a/run.c
+++ b/run.c
@@ -766,8 +766,8 @@ void generate(Transformer *transformer, Tokenizer *tokenizer, Sampler *sampler, 
 
         // print the token as string, decode it with the Tokenizer object
         char* piece = decode(tokenizer, token, next);
-        safe_printf(piece); // same as printf("%s", piece), but skips "unsafe" bytes
-        fflush(stdout);
+        //safe_printf(piece); // same as printf("%s", piece), but skips "unsafe" bytes
+        //fflush(stdout);
         token = next;
 
         // init the timer here because the first iteration can be slower

--- a/run.c
+++ b/run.c
@@ -739,6 +739,9 @@ void generate(Transformer *transformer, Tokenizer *tokenizer, Sampler *sampler, 
         exit(EXIT_FAILURE);
     }
 
+    // Print length of tokenized prompt.
+    fprintf(stderr, "# of prompt tokens: %d\n", num_prompt_tokens);
+
     // start the main loop
     long start = 0;  // used to time our code, only initialized after first iteration
     long ctx = 0;    // used to time context-encoding


### PR DESCRIPTION
### Changes

  - Split perf prints between context-encoding & token-generation
  - print length of tokenized prompt
  - comment token printfs
  
  These changes are necessary to support benchmarking in https://github.com/modularml/llama-benchmarking